### PR TITLE
Added generic save and download

### DIFF
--- a/ragmetrics/tasks.py
+++ b/ragmetrics/tasks.py
@@ -1,60 +1,27 @@
+from .api import RagMetricsObject  # This is your HTTP client wrapper for RagMetrics
 
-from .api import ragmetrics_client  # This is your HTTP client wrapper for RagMetrics
+class Task(RagMetricsObject):
+    object_type = "task" 
 
-class Task:
-    def __init__(self, name,model, prompt=""):
+    def __init__(self, name, model, prompt=""):
         self.name = name
+        self.model = model
         self.prompt = prompt
-        self.model = model  
         self.id = None
 
     def to_dict(self):
-        """Convert the Task instance into a dictionary for API requests."""
         return {
             "taskName": self.name,
             "taskPrompt": self.prompt,
-            "taskModel": self.model  
+            "taskModel": self.model
         }
 
-    def save(self):
-        """
-        Saves the task to RagMetrics by calling the API endpoint.
-        """
-        payload = self.to_dict()
-        headers = {"Authorization": f"Token {ragmetrics_client.access_token}"}
-        response = ragmetrics_client._make_request(
-            method="post",
-            endpoint="/api/client/task/save/",
-            json=payload,
-            headers=headers
-        )
-        if response.status_code == 200:
-            json_resp = response.json()
-            self.id = json_resp.get("task", {}).get("id")
-        else:
-            raise Exception("Failed to save task: " + response.text)
-
     @classmethod
-    def download(cls, id):
-        """
-        Downloads a task from RagMetrics.
-        """
-        headers = {"Authorization": f"Token {ragmetrics_client.access_token}"}
-        endpoint = f"/api/client/task/download/?id={id}"
-        response = ragmetrics_client._make_request(
-            method="get",
-            endpoint=endpoint,
-            headers=headers
+    def from_dict(cls, data: dict):
+        task = cls(
+            name=data.get("taskName", ""),
+            prompt=data.get("taskPrompt", ""),
+            model=data.get("taskModel", "")
         )
-        if response.status_code == 200:
-            json_resp = response.json()
-            task_data = json_resp.get("task", {})
-            task = cls(
-                name=task_data.get("taskName", ""),
-                prompt=task_data.get("taskPrompt", ""),
-                model=task_data.get("taskModel", "")
-            )
-            task.id = task_data.get("id")
-            return task
-        else:
-            raise Exception("Failed to download task: " + response.text)
+        task.id = data.get("id")
+        return task


### PR DESCRIPTION
> Can we create generic save() and load() methods that will handle any type of RagMetrics object?
> 
> The request and response would include the object type (task, dataset, experiment, example, etc). Based on this the server will know what django model to use for the .save() and the client will know what local class to use for the .load().
> 
> The goal would be to write these methods once, and support all of our objects.

Created a generic save and download object that can be used in task, dataset, example etc.